### PR TITLE
Remove doCalc from calc interface

### DIFF
--- a/calc-components/calccomponent.cpp
+++ b/calc-components/calccomponent.cpp
@@ -15,7 +15,7 @@ bool CalcComponent::tryStartCalc(int sampleCount)
 {
     bool calcDoneByMe = m_accessStrategy->tryMakeBusy();
     if(calcDoneByMe) {
-        doCalc(sampleCount);
+        m_doCalcHandler(sampleCount);
         m_accessStrategy->setDone();
     }
     return calcDoneByMe;
@@ -24,9 +24,4 @@ bool CalcComponent::tryStartCalc(int sampleCount)
 bool CalcComponent::isDone() const
 {
     return m_accessStrategy->isDone();
-}
-
-void CalcComponent::doCalc(int sampleCount)
-{
-    m_doCalcHandler(sampleCount);
 }

--- a/calc-components/calccomponent.h
+++ b/calc-components/calccomponent.h
@@ -12,8 +12,6 @@ public:
     virtual void prepareNextCalc() override final;
     virtual bool tryStartCalc(int sampleCount) override final;
     virtual bool isDone() const override final;
-protected:
-    virtual void doCalc(int sampleCount) override final;
 private:
     AbstractAccessStrategy::Ptr m_accessStrategy;
     std::function<void(int)> m_doCalcHandler = nullptr;

--- a/calc-components/calccomposite.cpp
+++ b/calc-components/calccomposite.cpp
@@ -5,10 +5,6 @@ CalcComposite::CalcComposite(std::vector<Ptr> components) :
 {
 }
 
-void CalcComposite::doCalc(int)
-{
-}
-
 void CalcComposite::prepareNextCalc()
 {
     for(auto component : m_components) {

--- a/calc-components/calccomposite.h
+++ b/calc-components/calccomposite.h
@@ -12,8 +12,6 @@ public:
     virtual void prepareNextCalc() override final;
     virtual bool tryStartCalc(int sampleCount) override final;
     virtual bool isDone() const override final;
-protected:
-    virtual void doCalc(int sampleCount) override final;
 private:
     std::vector<Ptr> m_components;
 };

--- a/calc-components/calcinterface.h
+++ b/calc-components/calcinterface.h
@@ -2,6 +2,7 @@
 #define CALCINTERFACE_H
 
 #include <memory>
+#include <functional>
 
 class CalcInterface
 {
@@ -11,8 +12,6 @@ public:
     virtual void prepareNextCalc() = 0;
     virtual bool tryStartCalc(int sampleCount) = 0;
     virtual bool isDone() const = 0;
-protected:
-    virtual void doCalc(int sampleCount) = 0;
 };
 
 #endif // CALCINTERFACE_H

--- a/calc-components/calculatorbase.h
+++ b/calc-components/calculatorbase.h
@@ -5,6 +5,7 @@
 #include "calccomposite.h"
 #include "buffers/buffertemplate.h"
 #include <vector>
+#include <functional>
 
 #define CALC_PTR(T) std::shared_ptr<CalculatorBase<T>>
 
@@ -15,6 +16,7 @@ class CalculatorBase : public CalcInterface
 public:
     CalculatorBase(std::vector<CalcInterface::Ptr> inputCalculators,
                    BUFFER_PTR(T) outputBuffer,
+                   std::function<void(int)> doCalcHandler,
                    AbstractAccessStrategy::Ptr accessStrategy);
     virtual void prepareNextCalc() override final;
     virtual bool tryStartCalc(int sampleCount) override final;
@@ -33,6 +35,7 @@ private:
     void doCalcCallback(int sampleCount);
     CalcComponent m_AccessComponent;
     CalcComposite m_inputsComposite;
+    std::function<void(int)> m_doCalcHandler = nullptr;
     int m_sampleOffset = 0;
     bool m_keepSampleOffsetOnNextTryStart = false;
 };

--- a/calc-components/calculatorbase_impl.h
+++ b/calc-components/calculatorbase_impl.h
@@ -6,10 +6,12 @@
 template <class T>
 CalculatorBase<T>::CalculatorBase(std::vector<CalcInterface::Ptr> inputCalculators,
                                   BUFFER_PTR(T) outputBuffer,
+                                  std::function<void(int)> doCalcHandler,
                                   AbstractAccessStrategy::Ptr accessStrategy) :
     m_AccessComponent([&](int sampleCount){doCalcCallback(sampleCount);}, accessStrategy),
     m_inputsComposite(inputCalculators),
-    m_outputBuffer(outputBuffer)
+    m_outputBuffer(outputBuffer),
+    m_doCalcHandler(doCalcHandler)
 {
 }
 
@@ -45,7 +47,7 @@ bool CalculatorBase<T>::tryStartCalc(int sampleCount)
 template <class T>
 void CalculatorBase<T>::doCalcCallback(int sampleCount)
 {
-    doCalc(sampleCount);
+    m_doCalcHandler(sampleCount);
     m_sampleOffset += sampleCount;
 }
 

--- a/calc-components/calculators/calculatoradd.h
+++ b/calc-components/calculators/calculatoradd.h
@@ -13,7 +13,6 @@ public:
                    BUFFER_PTR(T1_OUT) output,
                    AbstractAccessStrategy::Ptr accessStrategy,
                    bool scalarBuff2 = false);
-    virtual void doCalc(int sampleCount) override;
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorAdd2<T1_OUT, T2>> createWithOutBuffer(
@@ -22,6 +21,7 @@ public:
             int bufferSize, bool
             scalarBuff2 = false);
 private:
+    void doCalc(int sampleCount);
     void doCalcBuff(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     void doCalcScalar(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     BUFFER_PTR(T1_OUT) m_buff1;

--- a/calc-components/calculators/calculatordiff.h
+++ b/calc-components/calculators/calculatordiff.h
@@ -13,7 +13,6 @@ public:
                     BUFFER_PTR(T1_OUT) output,
                     AbstractAccessStrategy::Ptr accessStrategy,
                     bool scalarSubtrahend = false);
-    virtual void doCalc(int sampleCount) override;
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorDiff2<T1_OUT, T2>> createWithOutBuffer(CALC_PTR(T1_OUT) minuent,
@@ -21,6 +20,7 @@ public:
                                                                             int bufferSize,
                                                                             bool scalarSubtrahend = false);
 private:
+    void doCalc(int sampleCount);
     void doCalcBuff(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     void doCalcScalar(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     BUFFER_PTR(T1_OUT) m_minuentBuffer;

--- a/calc-components/calculators/calculatorfftw.h
+++ b/calc-components/calculators/calculatorfftw.h
@@ -4,6 +4,7 @@
 #include "calc-components/calculatorbase.h"
 #include "buffers/buffertemplate.h"
 #include <complex>
+#include <functional>
 
 template <class T>
 class CalculatorFftw : public CalculatorBase<std::complex<T>>
@@ -11,8 +12,9 @@ class CalculatorFftw : public CalculatorBase<std::complex<T>>
 public:
     CalculatorFftw(CALC_PTR(T) inReal,
                    BUFFER_PTR(std::complex<T>) outFft,
+                   std::function<void(int)> doCalcHandler,
                    AbstractAccessStrategy::Ptr accessStrategy) :
-        CalculatorBase<std::complex<T>>({inReal}, outFft, accessStrategy),
+        CalculatorBase<std::complex<T>>({inReal}, outFft, doCalcHandler, accessStrategy),
         m_inBuff(inReal->getOutputBuffer())
     {}
 protected:

--- a/calc-components/calculators/calculatorfftwfloat.cpp
+++ b/calc-components/calculators/calculatorfftwfloat.cpp
@@ -4,7 +4,11 @@
 CalculatorFftwFloat::CalculatorFftwFloat(CALC_PTR(float) inReal,
                                          BUFFER_PTR(std::complex<float>) outFft,
                                          AbstractAccessStrategy::Ptr accessStrategy) :
-    CalculatorFftw<float>(inReal, outFft, accessStrategy)
+    CalculatorFftw<float>(
+        inReal,
+        outFft,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy)
 {
     // we work with bare pointers -> check
     if(m_outputBuffer->size() < inReal->getOutputBuffer()->size()) {

--- a/calc-components/calculators/calculatorfftwfloat.h
+++ b/calc-components/calculators/calculatorfftwfloat.h
@@ -11,7 +11,6 @@ public:
                         BUFFER_PTR(std::complex<float>) outFft,
                         AbstractAccessStrategy::Ptr accessStrategy);
     virtual ~CalculatorFftwFloat();
-    virtual void doCalc(int) override;
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorFftw> createWithOutBuffer(CALC_PTR(float) inReal,
                                                                int bufferSize)
@@ -21,6 +20,7 @@ public:
                                                      createAccessStrategy<ACCESS_STRATEGY>());
     }
 private:
+    void doCalc(int);
     fftwf_plan m_fftwPlan = nullptr;
 };
 

--- a/calc-components/calculators/calculatorfftwinv.h
+++ b/calc-components/calculators/calculatorfftwinv.h
@@ -11,8 +11,9 @@ class CalculatorFftwInv : public CalculatorBase<T>
 public:
     CalculatorFftwInv(CALC_PTR(std::complex<T>) inFft,
                       BUFFER_PTR(T) outReal,
+                      std::function<void(int)> doCalcHandler,
                       AbstractAccessStrategy::Ptr accessStrategy) :
-        CalculatorBase<T>({inFft}, outReal, accessStrategy),
+        CalculatorBase<T>({inFft}, outReal, doCalcHandler, accessStrategy),
         m_inBuff(inFft->getOutputBuffer())
     {}
 protected:

--- a/calc-components/calculators/calculatorfftwinvfloat.cpp
+++ b/calc-components/calculators/calculatorfftwinvfloat.cpp
@@ -3,7 +3,11 @@
 CalculatorFftwInvFloat::CalculatorFftwInvFloat(CALC_PTR(std::complex<float>) inFft,
                                                BUFFER_PTR(float) outReal,
                                                AbstractAccessStrategy::Ptr accessStrategy) :
-    CalculatorFftwInv<float>({inFft}, outReal, accessStrategy)
+    CalculatorFftwInv<float>(
+        {inFft},
+        outReal,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy)
 {
     // we work with bare pointers -> check
     if(m_outputBuffer->size() < inFft->getOutputBuffer()->size()) {

--- a/calc-components/calculators/calculatorfftwinvfloat.h
+++ b/calc-components/calculators/calculatorfftwinvfloat.h
@@ -11,7 +11,6 @@ public:
                            BUFFER_PTR(float) outReal,
                            AbstractAccessStrategy::Ptr accessStrategy);
     virtual ~CalculatorFftwInvFloat();
-    virtual void doCalc(int) override;
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorFftwInv> createWithOutBuffer(CALC_PTR(std::complex<float>) inFft, int bufferSize)
     {
@@ -20,6 +19,7 @@ public:
                                                         createAccessStrategy<ACCESS_STRATEGY>());
     }
 private:
+    void doCalc(int);
     fftwf_plan m_fftwPlan = nullptr;
 };
 

--- a/calc-components/calculators/calculatormult.h
+++ b/calc-components/calculators/calculatormult.h
@@ -13,7 +13,6 @@ public:
                     BUFFER_PTR(T1_OUT) output,
                     AbstractAccessStrategy::Ptr accessStrategy,
                     bool scalarBuff2 = false);
-    virtual void doCalc(int sampleCount) override;
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorMult2<T1_OUT, T2>> createWithOutBuffer(CALC_PTR(T1_OUT) inCalc1,
@@ -21,6 +20,7 @@ public:
                                                                             int bufferSize,
                                                                             bool scalarBuff2 = false);
 private:
+    void doCalc(int sampleCount);
     void doCalcBuff(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     void doCalcScalar(int sampleCount, BUFFER_PTR(T1_OUT) outBuff);
     BUFFER_PTR(T1_OUT) m_buff1;

--- a/calc-components/calculators/calculatornull.h
+++ b/calc-components/calculators/calculatornull.h
@@ -11,9 +11,8 @@ class CalculatorNull : public CalculatorBase<T>
 public:
     CalculatorNull(BUFFER_PTR(T) output,
                    AbstractAccessStrategy::Ptr accessStrategy) :
-        CalculatorBase<T>(std::vector<CalcInterface::Ptr> {}, output, accessStrategy)
+        CalculatorBase<T>(std::vector<CalcInterface::Ptr> {}, output, [&](int){ }, accessStrategy)
     {}
-    virtual void doCalc(int) override { }
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalculatorNull<T>> createWithOutBuffer(int bufferSize)

--- a/calc-components/calculators/convertfloatingtointeger.h
+++ b/calc-components/calculators/convertfloatingtointeger.h
@@ -14,7 +14,6 @@ public:
                              BUFFER_PTR(I_TYPE) output,
                              AbstractAccessStrategy::Ptr accessStrategy,
                              I_TYPE scalingFactor = m_defaultScalingFactor);
-    virtual void doCalc(int sampleCount) override;
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<ConvertFloatingToInteger<F_TYPE, I_TYPE>> createWithOutBuffer(CALC_PTR(F_TYPE) floatIn, int bufferSize,
@@ -23,6 +22,7 @@ public:
     static constexpr I_TYPE m_defaultScalingFactor = std::numeric_limits<I_TYPE>::max();
 
 private:
+    void doCalc(int sampleCount);
     I_TYPE m_scalingFactor;
     BUFFER_PTR(F_TYPE) m_inBuff;
 };

--- a/calc-components/calculators/convertintegertofloating.h
+++ b/calc-components/calculators/convertintegertofloating.h
@@ -14,7 +14,6 @@ public:
                              BUFFER_PTR(F_TYPE) output,
                              AbstractAccessStrategy::Ptr accessStrategy,
                              F_TYPE scalingFactor = m_defaultScalingFactor);
-    virtual void doCalc(int sampleCount) override;
 
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<ConvertIntegerToFloating<I_TYPE, F_TYPE>> createWithOutBuffer(CALC_PTR(I_TYPE) floatIn, int bufferSize,
@@ -23,6 +22,7 @@ public:
     static constexpr F_TYPE m_defaultScalingFactor = (F_TYPE)std::numeric_limits<I_TYPE>::max();
 
 private:
+    void doCalc(int sampleCount);
     F_TYPE m_scalingFactor;
     BUFFER_PTR(I_TYPE) m_inBuff;
 };

--- a/calc-components/calculators/implementation-headers/calculatoradd_impl.h
+++ b/calc-components/calculators/implementation-headers/calculatoradd_impl.h
@@ -9,7 +9,11 @@ CalculatorAdd2<T1_OUT, T2>::CalculatorAdd2(CALC_PTR(T1_OUT) buff1,
                                            BUFFER_PTR(T1_OUT) output,
                                            AbstractAccessStrategy::Ptr accessStrategy,
                                            bool scalarBuff2) :
-    CalculatorBase<T1_OUT>(std::vector<CalcInterface::Ptr> {buff1, buff2}, output, accessStrategy),
+    CalculatorBase<T1_OUT>(
+        std::vector<CalcInterface::Ptr> {buff1, buff2},
+        output,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy),
     m_buff1(buff1->getOutputBuffer()),
     m_buff2(buff2->getOutputBuffer()),
     m_scalarBuff2(scalarBuff2)

--- a/calc-components/calculators/implementation-headers/calculatordiff_impl.h
+++ b/calc-components/calculators/implementation-headers/calculatordiff_impl.h
@@ -9,7 +9,11 @@ CalculatorDiff2<T1_OUT, T2>::CalculatorDiff2(CALC_PTR(T1_OUT) minuent,
                                              BUFFER_PTR(T1_OUT) output,
                                              AbstractAccessStrategy::Ptr accessStrategy,
                                              bool scalarSubtrahend) :
-    CalculatorBase<T1_OUT>(std::vector<CalcInterface::Ptr> {minuent, subtrahent}, output, accessStrategy),
+    CalculatorBase<T1_OUT>(
+        std::vector<CalcInterface::Ptr> {minuent, subtrahent},
+        output,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy),
     m_minuentBuffer(minuent->getOutputBuffer()),
     m_subtrahentBuffer(subtrahent->getOutputBuffer()),
     m_scalarSubtrahend(scalarSubtrahend)

--- a/calc-components/calculators/implementation-headers/calculatormult_impl.h
+++ b/calc-components/calculators/implementation-headers/calculatormult_impl.h
@@ -9,7 +9,11 @@ CalculatorMult2<T1_OUT, T2>::CalculatorMult2(CALC_PTR(T1_OUT) inCalc1,
                                              BUFFER_PTR(T1_OUT) output,
                                              AbstractAccessStrategy::Ptr accessStrategy,
                                              bool scalarBuff2) :
-    CalculatorBase<T1_OUT>(std::vector<CalcInterface::Ptr> {inCalc1, inCalc2}, output, accessStrategy),
+    CalculatorBase<T1_OUT>(
+        std::vector<CalcInterface::Ptr> {inCalc1, inCalc2},
+        output,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy),
     m_buff1(inCalc1->getOutputBuffer()),
     m_buff2(inCalc2->getOutputBuffer()),
     m_scalarBuff2(scalarBuff2)

--- a/calc-components/calculators/implementation-headers/convertfloatingtointeger_impl.h
+++ b/calc-components/calculators/implementation-headers/convertfloatingtointeger_impl.h
@@ -8,7 +8,11 @@ ConvertFloatingToInteger<F_TYPE, I_TYPE>::ConvertFloatingToInteger(CALC_PTR(F_TY
                                                                    BUFFER_PTR(I_TYPE) output,
                                                                    AbstractAccessStrategy::Ptr accessStrategy,
                                                                    I_TYPE scalingFactor) :
-    CalculatorBase<I_TYPE>(std::vector<CalcInterface::Ptr> {input}, output, accessStrategy),
+    CalculatorBase<I_TYPE>(
+        std::vector<CalcInterface::Ptr> {input},
+        output,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy),
     m_scalingFactor(scalingFactor),
     m_inBuff(input->getOutputBuffer())
 {

--- a/calc-components/calculators/implementation-headers/convertintegertofloating_impl.h
+++ b/calc-components/calculators/implementation-headers/convertintegertofloating_impl.h
@@ -9,7 +9,11 @@ ConvertIntegerToFloating<I_TYPE, F_TYPE>::ConvertIntegerToFloating(CALC_PTR(I_TY
                                                                    BUFFER_PTR(F_TYPE) output,
                                                                    AbstractAccessStrategy::Ptr accessStrategy,
                                                                    F_TYPE scalingFactor) :
-    CalculatorBase<F_TYPE>(std::vector<CalcInterface::Ptr> {input}, output, accessStrategy),
+    CalculatorBase<F_TYPE>(
+        std::vector<CalcInterface::Ptr> {input},
+        output,
+        [&](int sampleCount){doCalc(sampleCount);},
+        accessStrategy),
     m_inBuff(input->getOutputBuffer())
 {
     if(!scalingFactor) {

--- a/tests/calcfortest.h
+++ b/tests/calcfortest.h
@@ -11,18 +11,13 @@ public:
     CalcForTest(CALC_PTR(T) in,
                 BUFFER_PTR(T) out,
                 AbstractAccessStrategy::Ptr accessStrategy) :
-        CalculatorBase<T>(std::vector<CalcInterface::Ptr> {in}, out, accessStrategy),
+        CalculatorBase<T>(
+            std::vector<CalcInterface::Ptr> {in},
+            out,
+            [&](int sampleCount){doCalc(sampleCount);},
+            accessStrategy),
         m_inBuffer(in->getOutputBuffer())
     {}
-    virtual void doCalc(int sampleCount) override
-    {
-        BUFFER_PTR(T) outBuff = CalculatorBase<T>::getOutputBuffer();
-        for(int i=0, currSample = CalculatorBase<T>::getSampleOffset();
-            i<sampleCount;
-            ++i, ++currSample) {
-            outBuff->at(currSample) = m_inBuffer->at(currSample);
-        }
-    };
     template <typename ACCESS_STRATEGY>
     static std::shared_ptr<CalcForTest<T>> createWithOutBuffer(CALC_PTR(T) in, int bufferSize)
     {
@@ -31,6 +26,15 @@ public:
                                                 createAccessStrategy<ACCESS_STRATEGY>());
     }
 private:
+    void doCalc(int sampleCount)
+    {
+        BUFFER_PTR(T) outBuff = CalculatorBase<T>::getOutputBuffer();
+        for(int i=0, currSample = CalculatorBase<T>::getSampleOffset();
+            i<sampleCount;
+            ++i, ++currSample) {
+            outBuff->at(currSample) = m_inBuffer->at(currSample);
+        }
+    };
     BUFFER_PTR(T) m_inBuffer;
 };
 


### PR DESCRIPTION
Replace it by a function pointer set by concrete implementations

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>